### PR TITLE
Add `requirements.txt` for PyTorch

### DIFF
--- a/pytorch_impl/requirements.txt
+++ b/pytorch_impl/requirements.txt
@@ -1,0 +1,5 @@
+torch==1.6
+torchvision==0.7.0
+numpy==1.19.1
+scipy==1.5.2
+psutil==5.8.0


### PR DESCRIPTION
The requirements I used to run PyTorch examples.